### PR TITLE
removed note about Mongo v2 driver only

### DIFF
--- a/mongo.md
+++ b/mongo.md
@@ -84,7 +84,6 @@ In addition to code annotation-processor, it's necessary to add the `mongo` anno
 _Mongo_ artifact required to be used for compilation as well be available at runtime.
 _Mongo_ module works closely with [Gson](/json.html#gson) module, which is also included as transitive dependency.
 
-**Note:** Current release works with versions `2.12+` of the MongoDB Java driver - version `3.0` and up is not yet supported.
 
 Snippet of Maven dependencies:
 


### PR DESCRIPTION
Old documentation can be misleading. Immutables now work with v3 driver (since 2.6.0)