### PR TITLE
add documentation on readonly repositories

### DIFF
--- a/mongo.md
+++ b/mongo.md
@@ -425,6 +425,18 @@ posts.findById(111)
     .upsert();
 ```
 
+### Read-only repositories
+For usecases when only read operations are required one can customize repository generation with `readonly` annotation parameter.
+When set to `true` (it is `false` by default) write, delete and update methods will not be available:
+```java
+@Value.Immutable
+@Mongo.Repository(readonly = true) // don't generate any write / delete / update methods
+public abstract class Item {
+  // ...
+}
+```
+To omit indexing operations use `index = false` parameter (indexing is enabled by default).
+
 ### Ensure Index
 
 If you want to ensure indices using code rather than the administrative tools,


### PR DESCRIPTION
Small paragraph on `readonly` and `index` parameters. This functionality was undocumented. 