### PR TITLE
Fix link to Value.Style

### DIFF
--- a/style.md
+++ b/style.md
@@ -16,7 +16,7 @@ combinations of customizations will work correctly.
 
 `@Value.Style` annotation has a number of attributes to
 customize generated the APIs and implementations. See the JavaDoc for
-[Value.Style](https://github.com/immutables/immutables/blob/master/value/src/org/immutables/value/Value.java#L308)
+[Value.Style](https://github.com/immutables/immutables/blob/master/value-annotations/src/org/immutables/value/Value.java#L416)
 
 In nutshell, using styles you can:
 


### PR DESCRIPTION
Followup to pull request #23 . This patch fixes the link and points to master instead of a specific commit.

