### PR TITLE
Updated Guava references from google code to github

### DIFF
--- a/immutable.md
+++ b/immutable.md
@@ -11,7 +11,7 @@ Overview
 
 To reap the benefits of immutability in Java, we created an annotation processor
 to easily create simple and consistent value objects. You can think of it as
-[Guava's Immutable Collections](https://code.google.com/p/guava-libraries/wiki/ImmutableCollectionsExplained) but for regular objects.
+[Guava's Immutable Collections](https://github.com/google/guava/wiki/ImmutableCollectionsExplained) but for regular objects.
 
 The core of _Immutables_ is modelling. Good modelling is at the heart of creating good applications and
 services, and of good design in general. We feel proud to fill a gap in the area of modelling in the Java programming language, where conventional JavaBeans are insufficient.

--- a/intro.md
+++ b/intro.md
@@ -19,7 +19,7 @@ It is used for the development of airline inventory systems, travel deal aggrega
 
 [Guava](https://code.google.com/p/guava-libraries) is used as an optional utility library for the generated classes,
 but in addition we employ an API style popularized by the "Effective Java, Second Edition" book and Guava Library.
-Use of `null` as an attribute value is rigorously prohibited ([Using and avoiding null explained](https://code.google.com/p/guava-libraries/wiki/UsingAndAvoidingNullExplained)).
+Use of `null` as an attribute value is rigorously prohibited ([Using and avoiding null explained](https://github.com/google/guava/wiki/UsingAndAvoidingNullExplained)).
 
 The _Immutables_ package does not use compiler hacks with AST transformations or companion languages: It uses annotation processing - a part of the standard Java compiler.
 Classes are generated during the compilation process and are not stored in source control, but the generated sources are easily inspected if necessary.


### PR DESCRIPTION
Previous references redirected to repository main page.

Following up from https://github.com/immutables/immutables.github.io/pull/24 this time on the right branch.