### PR TITLE
Documents `defaultAsDefault`

### DIFF
--- a/immutable.md
+++ b/immutable.md
@@ -608,6 +608,9 @@ interface Val {
 }
 ```
 
+Since version `2.0.15`, the `defaultAsDefault` style parameter (`@Value.Style(strictBuilder = true, ...)`) is supported.
+This instructes generated builders to treat Java 8 default methods in interfaces as if they were annotated with `@Value.Default`. 
+
 <a name="derived-attribute"></a>
 ### Derived attributes
 Derived attributes are attributes with values that are read from existing immutable instances, but

--- a/immutable.md
+++ b/immutable.md
@@ -608,7 +608,7 @@ interface Val {
 }
 ```
 
-Since version `2.0.15`, the `defaultAsDefault` style parameter (`@Value.Style(strictBuilder = true, ...)`) is supported.
+Since version `2.0.15`, the `defaultAsDefault` style parameter (`@Value.Style(defaultAsDefault = true, ...)`) is supported.
 This instructes generated builders to treat Java 8 default methods in interfaces as if they were annotated with `@Value.Default`. 
 
 <a name="derived-attribute"></a>


### PR DESCRIPTION
This is a helpful configuration option that I didn't discover until
reading the `@Value.Style` source code. I've seen it asked about in at
least one issue as well, so I think it would be helpful to mention on
the guide.