### PR TITLE
Version upgrade 2.8.2 -> 2.9.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ markdown: redcarpet
 exclude: [README.md]
 
 # latest version available in templates under site.v
-v: 2.8.2
+v: 2.9.0
 
 # rootUri for maven central artifactId
 depUri: https://search.maven.org/artifact/org.immutables


### PR DESCRIPTION
The website was showing the latest version as 2.8.2.
I had used this version before and it worked fine.
After using such a version on IntelliJ, some issue seems to occur in the annotation processing.
Using the `@Builder` annotations, the builder class is generated inside the generated-sources dir.
But the IDE can't find the build to import.

Everything works fine by just upgrading to 2.9.0.
Since I copied the maven dependencies from the website, it took me a while to find out the issue was with the lib version.
This way, I changed the website to show the latest version.
I hope it helps other users that may face the same issues with the 2.8.2 releasse.